### PR TITLE
Add dependabot auto updates (#8)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: "/"
+    # Check the npm registry for updates every day (weekdays)
+    schedule:
+      interval: "daily"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
       "devDependencies": {
         "@types/react": "^18.2.15",
         "@types/react-dom": "^18.2.7",
-        "@typescript-eslint/eslint-plugin": "^6.0.0",
-        "@typescript-eslint/parser": "^6.0.0",
+        "@typescript-eslint/eslint-plugin": "^6.5.0",
+        "@typescript-eslint/parser": "^6.5.0",
         "@vitejs/plugin-react-swc": "^3.3.2",
         "eslint": "^8.45.0",
         "eslint-plugin-react-hooks": "^4.6.0",
@@ -797,22 +797,22 @@
       "dev": true
     },
     "node_modules/@types/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.1.tgz",
+      "integrity": "sha512-cJRQXpObxfNKkFAZbJl2yjWtJCqELQIdShsogr1d2MilP8dKD9TE/nEKHkJgUNHdGKCQaf9HbIynuV2csLGVLg==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.4.1.tgz",
-      "integrity": "sha512-3F5PtBzUW0dYlq77Lcqo13fv+58KDwUib3BddilE8ajPJT+faGgxmI9Sw+I8ZS22BYwoir9ZhNXcLi+S+I2bkw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.5.0.tgz",
+      "integrity": "sha512-2pktILyjvMaScU6iK3925uvGU87E+N9rh372uGZgiMYwafaw9SXq86U04XPq3UH6tzRvNgBsub6x2DacHc33lw==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.4.1",
-        "@typescript-eslint/type-utils": "6.4.1",
-        "@typescript-eslint/utils": "6.4.1",
-        "@typescript-eslint/visitor-keys": "6.4.1",
+        "@typescript-eslint/scope-manager": "6.5.0",
+        "@typescript-eslint/type-utils": "6.5.0",
+        "@typescript-eslint/utils": "6.5.0",
+        "@typescript-eslint/visitor-keys": "6.5.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -838,15 +838,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.4.1.tgz",
-      "integrity": "sha512-610G6KHymg9V7EqOaNBMtD1GgpAmGROsmfHJPXNLCU9bfIuLrkdOygltK784F6Crboyd5tBFayPB7Sf0McrQwg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.5.0.tgz",
+      "integrity": "sha512-LMAVtR5GN8nY0G0BadkG0XIe4AcNMeyEy3DyhKGAh9k4pLSMBO7rF29JvDBpZGCmp5Pgz5RLHP6eCpSYZJQDuQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.4.1",
-        "@typescript-eslint/types": "6.4.1",
-        "@typescript-eslint/typescript-estree": "6.4.1",
-        "@typescript-eslint/visitor-keys": "6.4.1",
+        "@typescript-eslint/scope-manager": "6.5.0",
+        "@typescript-eslint/types": "6.5.0",
+        "@typescript-eslint/typescript-estree": "6.5.0",
+        "@typescript-eslint/visitor-keys": "6.5.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -866,13 +866,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.4.1.tgz",
-      "integrity": "sha512-p/OavqOQfm4/Hdrr7kvacOSFjwQ2rrDVJRPxt/o0TOWdFnjJptnjnZ+sYDR7fi4OimvIuKp+2LCkc+rt9fIW+A==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.5.0.tgz",
+      "integrity": "sha512-A8hZ7OlxURricpycp5kdPTH3XnjG85UpJS6Fn4VzeoH4T388gQJ/PGP4ole5NfKt4WDVhmLaQ/dBLNDC4Xl/Kw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.4.1",
-        "@typescript-eslint/visitor-keys": "6.4.1"
+        "@typescript-eslint/types": "6.5.0",
+        "@typescript-eslint/visitor-keys": "6.5.0"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -883,13 +883,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.4.1.tgz",
-      "integrity": "sha512-7ON8M8NXh73SGZ5XvIqWHjgX2f+vvaOarNliGhjrJnv1vdjG0LVIz+ToYfPirOoBi56jxAKLfsLm40+RvxVVXA==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.5.0.tgz",
+      "integrity": "sha512-f7OcZOkRivtujIBQ4yrJNIuwyCQO1OjocVqntl9dgSIZAdKqicj3xFDqDOzHDlGCZX990LqhLQXWRnQvsapq8A==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.4.1",
-        "@typescript-eslint/utils": "6.4.1",
+        "@typescript-eslint/typescript-estree": "6.5.0",
+        "@typescript-eslint/utils": "6.5.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -910,9 +910,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.4.1.tgz",
-      "integrity": "sha512-zAAopbNuYu++ijY1GV2ylCsQsi3B8QvfPHVqhGdDcbx/NK5lkqMnCGU53amAjccSpk+LfeONxwzUhDzArSfZJg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.5.0.tgz",
+      "integrity": "sha512-eqLLOEF5/lU8jW3Bw+8auf4lZSbbljHR2saKnYqON12G/WsJrGeeDHWuQePoEf9ro22+JkbPfWQwKEC5WwLQ3w==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -923,13 +923,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.4.1.tgz",
-      "integrity": "sha512-xF6Y7SatVE/OyV93h1xGgfOkHr2iXuo8ip0gbfzaKeGGuKiAnzS+HtVhSPx8Www243bwlW8IF7X0/B62SzFftg==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.5.0.tgz",
+      "integrity": "sha512-q0rGwSe9e5Kk/XzliB9h2LBc9tmXX25G0833r7kffbl5437FPWb2tbpIV9wAATebC/018pGa9fwPDuvGN+LxWQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.4.1",
-        "@typescript-eslint/visitor-keys": "6.4.1",
+        "@typescript-eslint/types": "6.5.0",
+        "@typescript-eslint/visitor-keys": "6.5.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -950,17 +950,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.4.1.tgz",
-      "integrity": "sha512-F/6r2RieNeorU0zhqZNv89s9bDZSovv3bZQpUNOmmQK1L80/cV4KEu95YUJWi75u5PhboFoKUJBnZ4FQcoqhDw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.5.0.tgz",
+      "integrity": "sha512-9nqtjkNykFzeVtt9Pj6lyR9WEdd8npPhhIPM992FWVkZuS6tmxHfGVnlUcjpUP2hv8r4w35nT33mlxd+Be1ACQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.4.1",
-        "@typescript-eslint/types": "6.4.1",
-        "@typescript-eslint/typescript-estree": "6.4.1",
+        "@typescript-eslint/scope-manager": "6.5.0",
+        "@typescript-eslint/types": "6.5.0",
+        "@typescript-eslint/typescript-estree": "6.5.0",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -975,12 +975,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.4.1.tgz",
-      "integrity": "sha512-y/TyRJsbZPkJIZQXrHfdnxVnxyKegnpEvnRGNam7s3TRR2ykGefEWOhaef00/UUN3IZxizS7BTO3svd3lCOJRQ==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.5.0.tgz",
+      "integrity": "sha512-yCB/2wkbv3hPsh02ZS8dFQnij9VVQXJMN/gbQsaaY+zxALkZnxa/wagvLEFsAWMPv7d7lxQmNsIzGU1w/T/WyA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.4.1",
+        "@typescript-eslint/types": "6.5.0",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "devDependencies": {
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
-    "@typescript-eslint/eslint-plugin": "^6.0.0",
-    "@typescript-eslint/parser": "^6.0.0",
+    "@typescript-eslint/eslint-plugin": "^6.5.0",
+    "@typescript-eslint/parser": "^6.5.0",
     "@vitejs/plugin-react-swc": "^3.3.2",
     "eslint": "^8.45.0",
     "eslint-plugin-react-hooks": "^4.6.0",


### PR DESCRIPTION
* Create dependabot.yml

* Bump @typescript-eslint/eslint-plugin from 6.4.1 to 6.5.0 (#7)

Bumps [@typescript-eslint/eslint-plugin](https://github.com/typescript-eslint/typescript-eslint/tree/HEAD/packages/eslint-plugin) from 6.4.1 to 6.5.0.
- [Release notes](https://github.com/typescript-eslint/typescript-eslint/releases)
- [Changelog](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/CHANGELOG.md)
- [Commits](https://github.com/typescript-eslint/typescript-eslint/commits/v6.5.0/packages/eslint-plugin)

---
updated-dependencies:
- dependency-name: "@typescript-eslint/eslint-plugin" dependency-type: direct:development update-type: version-update:semver-minor ...




* Bump @typescript-eslint/parser from 6.4.1 to 6.5.0 (#6)

Bumps [@typescript-eslint/parser](https://github.com/typescript-eslint/typescript-eslint/tree/HEAD/packages/parser) from 6.4.1 to 6.5.0.
- [Release notes](https://github.com/typescript-eslint/typescript-eslint/releases)
- [Changelog](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/parser/CHANGELOG.md)
- [Commits](https://github.com/typescript-eslint/typescript-eslint/commits/v6.5.0/packages/parser)

---
updated-dependencies:
- dependency-name: "@typescript-eslint/parser" dependency-type: direct:development update-type: version-update:semver-minor ...




---------